### PR TITLE
fix: respect PI_CODING_AGENT_DIR when scanning sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Files in `notes/` and older daily logs are **not** injected — they're accessib
 
 | Env Var | Default | Description |
 |---------|---------|-------------|
-| `PI_MEMORY_DIR` | `~/.pi/agent/memory/` | Root directory for all memory files |
+| `PI_CODING_AGENT_DIR` | `~/.pi/agent/` | Base pi directory (used for session scanning and memory defaults) |
+| `PI_MEMORY_DIR` | `$PI_CODING_AGENT_DIR/memory/` | Root directory for all memory files |
 | `PI_DAILY_DIR` | `$PI_MEMORY_DIR/daily/` | Directory for daily logs |
 | `PI_CONTEXT_FILES` | *(empty)* | Comma-separated list of extra files to inject into context (e.g. `SOUL.md,AGENTS.md,HEARTBEAT.md`) |
 | `PI_AUTOCOMMIT` | `false` | When `1` or `true`, auto-commit to git after every write |

--- a/index.ts
+++ b/index.ts
@@ -66,7 +66,7 @@ function gitCommit(message: string) {
 
 // --- Session scanner for "Last 24h" dashboard ---
 
-const SESSIONS_DIR = path.join(process.env.HOME ?? "~", ".pi", "agent", "sessions");
+const SESSIONS_DIR = config.sessionDir;
 const SUMMARY_CACHE = path.join(config.dailyDir, "cache.json");
 const REBUILD_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;

--- a/lib.ts
+++ b/lib.ts
@@ -16,12 +16,14 @@ export interface MemoryConfig {
 	scratchpadFile: string;
 	dailyDir: string;
 	notesDir: string;
+	sessionDir: string;
 	contextFiles: string[];
 	autocommit: boolean;
 }
 
 export function buildConfig(env: Record<string, string | undefined> = process.env): MemoryConfig {
-	const memoryDir = env.PI_MEMORY_DIR ?? path.join(env.HOME ?? "~", ".pi", "agent", "memory");
+	const agentDir = env.PI_CODING_AGENT_DIR ?? path.join(env.HOME ?? "~", ".pi", "agent");
+	const memoryDir = env.PI_MEMORY_DIR ?? path.join(agentDir, "memory");
 	const dailyDir = env.PI_DAILY_DIR ?? path.join(memoryDir, "daily");
 	const contextFiles = (env.PI_CONTEXT_FILES ?? "")
 		.split(",")
@@ -35,6 +37,7 @@ export function buildConfig(env: Record<string, string | undefined> = process.en
 		scratchpadFile: path.join(memoryDir, "SCRATCHPAD.md"),
 		dailyDir,
 		notesDir: path.join(memoryDir, "notes"),
+		sessionDir: path.join(agentDir, "sessions"),
 		contextFiles,
 		autocommit,
 	};

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,5 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import * as path from "node:path";
 import { buildConfig } from "../lib.ts";
 
 describe("buildConfig", () => {
@@ -11,6 +10,7 @@ describe("buildConfig", () => {
 		assert.strictEqual(config.scratchpadFile, "/home/testuser/.pi/agent/memory/SCRATCHPAD.md");
 		assert.strictEqual(config.dailyDir, "/home/testuser/.pi/agent/memory/daily");
 		assert.strictEqual(config.notesDir, "/home/testuser/.pi/agent/memory/notes");
+		assert.strictEqual(config.sessionDir, "/home/testuser/.pi/agent/sessions");
 		assert.deepStrictEqual(config.contextFiles, []);
 		assert.strictEqual(config.autocommit, false);
 	});
@@ -27,6 +27,13 @@ describe("buildConfig", () => {
 		const config = buildConfig({ HOME: "/home/x", PI_DAILY_DIR: "/other/daily" });
 		assert.strictEqual(config.dailyDir, "/other/daily");
 		assert.strictEqual(config.memoryDir, "/home/x/.pi/agent/memory");
+		assert.strictEqual(config.sessionDir, "/home/x/.pi/agent/sessions");
+	});
+
+	it("respects PI_CODING_AGENT_DIR for memory and sessions defaults", () => {
+		const config = buildConfig({ HOME: "/home/x", PI_CODING_AGENT_DIR: "/xdg/pi" });
+		assert.strictEqual(config.memoryDir, "/xdg/pi/memory");
+		assert.strictEqual(config.sessionDir, "/xdg/pi/sessions");
 	});
 
 	it("parses PI_CONTEXT_FILES as comma-separated list", () => {
@@ -67,5 +74,6 @@ describe("buildConfig", () => {
 	it("falls back to ~ when HOME is undefined", () => {
 		const config = buildConfig({});
 		assert.strictEqual(config.memoryDir, "~/.pi/agent/memory");
+		assert.strictEqual(config.sessionDir, "~/.pi/agent/sessions");
 	});
 });


### PR DESCRIPTION
## Summary
- derive `sessionDir` from `PI_CODING_AGENT_DIR` in `buildConfig()`
- use `config.sessionDir` for dashboard session scanning
- add config tests for `sessionDir` defaults and `PI_CODING_AGENT_DIR` override
- update README config table to document `PI_CODING_AGENT_DIR`

## Why
The dashboard scanner previously used a hard-coded `~/.pi/agent/sessions` path, which breaks setups that run pi with a custom `PI_CODING_AGENT_DIR` (e.g. XDG layouts).

## Validation
- `npm test --silent`
- 103/103 tests passing
