### PR TITLE
Lucky5th windows session dir

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,6 +50,7 @@ import {
 	scanSession,
 	isHousekeeping,
 	searchMemory,
+	getHomeDir
 } from "./lib.ts";
 
 const config = buildConfig();
@@ -65,10 +66,8 @@ function gitCommit(message: string) {
 }
 
 // --- Session scanner for "Last 24h" dashboard ---
-
-const isWin32 = path.win32.sep === path.sep;
-const HOME = isWin32 ? process.env.HOMEPATH : process.env.HOME ?? "~";
-const SESSIONS_DIR = path.join(HOME ?? "~", ".pi", "agent", "sessions");
+const home = getHomeDir();
+const SESSIONS_DIR = path.join(home, ".pi", "agent", "sessions");
 const SUMMARY_CACHE = path.join(config.dailyDir, "cache.json");
 const REBUILD_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;

--- a/index.ts
+++ b/index.ts
@@ -66,7 +66,9 @@ function gitCommit(message: string) {
 
 // --- Session scanner for "Last 24h" dashboard ---
 
-const SESSIONS_DIR = path.join(process.env.HOME ?? "~", ".pi", "agent", "sessions");
+const isWin32 = path.win32.sep === path.sep;
+const HOME = isWin32 ? process.env.HOMEPATH : process.env.HOME ?? "~";
+const SESSIONS_DIR = path.join(HOME ?? "~", ".pi", "agent", "sessions");
 const SUMMARY_CACHE = path.join(config.dailyDir, "cache.json");
 const REBUILD_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;

--- a/lib.ts
+++ b/lib.ts
@@ -28,6 +28,11 @@ export interface FileConfig {
 	autocommit?: boolean;
 }
 
+export function getHomeDir(env: Record<string, string | undefined> = process.env) : string {
+	const isWin32 = path.win32.sep === path.sep;
+	return isWin32 ? env.HOMEPATH : env.HOME ?? "~";
+}
+
 export function loadConfigFile(memoryDir: string): FileConfig {
 	try {
 		const raw = fs.readFileSync(path.join(memoryDir, ".pi-mem.json"), "utf-8");
@@ -51,7 +56,8 @@ function parseCommaSeparated(value: string | undefined): string[] | undefined {
 }
 
 export function buildConfig(env: Record<string, string | undefined> = process.env): MemoryConfig {
-	const memoryDir = env.PI_MEMORY_DIR ?? path.join(env.HOME ?? "~", ".pi", "agent", "memory");
+	const home = getHomeDir(env);
+	const memoryDir = env.PI_MEMORY_DIR ?? path.join(home, ".pi", "agent", "memory");
 
 	// Load config.json from memory dir (env vars override file values)
 	const fileConfig = loadConfigFile(memoryDir);


### PR DESCRIPTION
Add support for HOMEPATH environment variable present when running in Windows. 

Resolves issue where pi-mem will create a literal directory `./~/` in the pi agents directory and in the current working directory on Windows systems.