### PR TITLE
fix: support latest pi memory context and paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -51,6 +51,7 @@ import {
 	scanSession,
 	isHousekeeping,
 	searchMemory,
+	resolveSessionsDir,
 } from "./lib.ts";
 
 const config = buildConfig();
@@ -67,7 +68,7 @@ function gitCommit(message: string) {
 
 // --- Session scanner for "Last 24h" dashboard ---
 
-const SESSIONS_DIR = path.join(process.env.HOME ?? "~", ".pi", "agent", "sessions");
+const SESSIONS_DIR = resolveSessionsDir();
 const SUMMARY_CACHE = path.join(config.dailyDir, "cache.json");
 const REBUILD_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;
@@ -344,12 +345,10 @@ export default function (pi: ExtensionAPI) {
 		if (rebuildTimer) { clearInterval(rebuildTimer); rebuildTimer = null; }
 	});
 
-	// Inject memory as a trailing system message (not in the main system prompt).
-	// This keeps the system prompt byte-stable across sessions so that KV prefix
-	// caches (e.g., ds4 disk cache keyed on SHA1 of token prefix) get hits.
+	// Inject memory as a trailing user message, leaving the stable system prompt
+	// untouched for prompt caching. Pi 0.81 drops unsupported system-role entries.
 	pi.on("context", async (event) => {
 		const memoryContext = buildMemoryContext(config);
-		if (!memoryContext) return;
 
 		const memoryInstructions = [
 			"## Memory",
@@ -369,8 +368,16 @@ export default function (pi: ExtensionAPI) {
 			memoryContext,
 		].join("\n");
 
-		const messages = [...event.messages, { role: "system", content: memoryInstructions }];
-		return { messages };
+		return {
+			messages: [
+				...event.messages,
+				{
+					role: "user" as const,
+					content: `<pi-mem-injected>\n${memoryInstructions}\n</pi-mem-injected>`,
+					timestamp: Date.now(),
+				},
+			],
+		};
 	});
 
 	pi.on("session_before_compact", async (_event, ctx) => {

--- a/lib.ts
+++ b/lib.ts
@@ -5,6 +5,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as os from "node:os";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
@@ -51,8 +52,32 @@ function parseCommaSeparated(value: string | undefined): string[] | undefined {
 	return items;
 }
 
+export function resolveHomeDir(
+	env: Record<string, string | undefined> = process.env,
+	fallback = os.homedir(),
+): string {
+	return env.HOME
+		?? env.USERPROFILE
+		?? (env.HOMEDRIVE && env.HOMEPATH ? `${env.HOMEDRIVE}${env.HOMEPATH}` : undefined)
+		?? fallback;
+}
+
+export function resolveAgentDir(
+	env: Record<string, string | undefined> = process.env,
+	fallbackHome = os.homedir(),
+): string {
+	return env.PI_CODING_AGENT_DIR ?? path.join(resolveHomeDir(env, fallbackHome), ".pi", "agent");
+}
+
+export function resolveSessionsDir(
+	env: Record<string, string | undefined> = process.env,
+	fallbackHome = os.homedir(),
+): string {
+	return path.join(resolveAgentDir(env, fallbackHome), "sessions");
+}
+
 export function buildConfig(env: Record<string, string | undefined> = process.env): MemoryConfig {
-	const memoryDir = env.PI_MEMORY_DIR ?? path.join(env.HOME ?? "~", ".pi", "agent", "memory");
+	const memoryDir = env.PI_MEMORY_DIR ?? path.join(resolveAgentDir(env), "memory");
 
 	// Load config.json from memory dir (env vars override file values)
 	const fileConfig = loadConfigFile(memoryDir);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import * as path from "node:path";
-import { buildConfig } from "../lib.ts";
+import { buildConfig, resolveAgentDir, resolveHomeDir, resolveSessionsDir } from "../lib.ts";
 import { makeTempDir, cleanup, writeFile } from "./helpers.ts";
 
 describe("buildConfig", () => {
@@ -153,8 +153,22 @@ describe("buildConfig", () => {
 		cleanup(memDir);
 	});
 
-	it("falls back to ~ when HOME is undefined", () => {
-		const config = buildConfig({});
-		assert.strictEqual(config.memoryDir, "~/.pi/agent/memory");
+	it("uses the supplied platform fallback when home variables are absent", () => {
+		assert.strictEqual(resolveHomeDir({}, "/fallback/home"), "/fallback/home");
+		assert.strictEqual(resolveAgentDir({}, "/fallback/home"), "/fallback/home/.pi/agent");
+	});
+
+	it("supports Windows USERPROFILE", () => {
+		assert.strictEqual(resolveHomeDir({ USERPROFILE: "C:\\Users\\test" }, "/fallback"), "C:\\Users\\test");
+	});
+
+	it("supports Windows HOMEDRIVE and HOMEPATH", () => {
+		assert.strictEqual(resolveHomeDir({ HOMEDRIVE: "C:", HOMEPATH: "\\Users\\test" }, "/fallback"), "C:\\Users\\test");
+	});
+
+	it("respects PI_CODING_AGENT_DIR for memory and sessions", () => {
+		const env = { HOME: "/home/x", PI_CODING_AGENT_DIR: "/custom/agent" };
+		assert.strictEqual(buildConfig(env).memoryDir, "/custom/agent/memory");
+		assert.strictEqual(resolveSessionsDir(env), "/custom/agent/sessions");
 	});
 });


### PR DESCRIPTION
## Summary
- inject memory through a Pi 0.81-compatible user context message while preserving the stable system-prompt prefix
- always inject memory instructions on fresh installs
- resolve home, agent, and session directories cross-platform
- respect `PI_CODING_AGENT_DIR`

## Tests
- `npm test` — 151 passed

Consolidates the focused fixes proposed in #6 and #7. Contributors are credited as co-authors in the commit.