### PR TITLE
chore: automate npm releases and prepare v1.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) != package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+      - run: npm ci --ignore-scripts
+      - name: Publish with provenance
+        run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askjo/pi-mem",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askjo/pi-mem",
-      "version": "1.0.1",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askjo/pi-mem",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Pi coding agent extension for plain-Markdown memory system — long-term memory, daily logs, and scratchpad checklist",
   "main": "index.ts",
   "type": "module",

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUMP="${1:-patch}"
+if [[ "$BUMP" != "patch" && "$BUMP" != "minor" && "$BUMP" != "major" ]]; then
+  echo "Usage: ./release.sh [patch|minor|major]"
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+
+echo "🔍 Pre-flight checks..."
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "❌ Working tree is dirty. Commit changes first."
+  exit 1
+fi
+if [[ "$(git branch --show-current)" != "main" ]]; then
+  echo "❌ Not on main."
+  exit 1
+fi
+git fetch origin main --quiet
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+  echo "❌ Local main differs from origin/main."
+  exit 1
+fi
+
+echo "🧪 Running tests..."
+npm test
+
+echo "📦 Bumping version: $BUMP"
+npm version "$BUMP" --message "v%s"
+NEW_VERSION=$(node -p "require('./package.json').version")
+
+echo "📤 Pushing main and v${NEW_VERSION} tag..."
+git push origin main --follow-tags
+
+echo "✅ Release v${NEW_VERSION} triggered"
+echo "   Actions: https://github.com/jo-inc/pi-mem/actions"
+echo "   Package: https://www.npmjs.com/package/@askjo/pi-mem"


### PR DESCRIPTION
## Summary
- add tag-triggered npm publishing with provenance
- add guarded local release script matching camofox-browser
- prepare package version 1.2.0

## Tests
- `npm test` — 151 passed

After merge, running `./release.sh patch` would bump past 1.2.0, so the initial v1.2.0 tag will be created directly from the merged release commit.