### PR TITLE
Fix Broken unit tests and improve cross platform support in file helpers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,6 +50,7 @@ import {
 	scanSession,
 	isHousekeeping,
 	searchMemory,
+	getHomeDir
 } from "./lib.ts";
 
 const config = buildConfig();
@@ -65,10 +66,8 @@ function gitCommit(message: string) {
 }
 
 // --- Session scanner for "Last 24h" dashboard ---
-
-const isWin32 = path.win32.sep === path.sep;
-const HOME = isWin32 ? process.env.HOMEPATH : process.env.HOME ?? "~";
-const SESSIONS_DIR = path.join(HOME ?? "~", ".pi", "agent", "sessions");
+const home = getHomeDir();
+const SESSIONS_DIR = path.join(home, ".pi", "agent", "sessions");
 const SUMMARY_CACHE = path.join(config.dailyDir, "cache.json");
 const REBUILD_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { StringEnum, completeSimple, getModel } from "@mariozechner/pi-ai";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
 
@@ -67,8 +68,8 @@ function gitCommit(message: string) {
 }
 
 // --- Session scanner for "Last 24h" dashboard ---
-const home = getHomeDir();
-const SESSIONS_DIR = path.join(home, ".pi", "agent", "sessions");
+
+const SESSIONS_DIR = path.join(os.homedir(), ".pi", "agent", "sessions");
 const SUMMARY_CACHE = path.join(config.dailyDir, "cache.json");
 const REBUILD_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;

--- a/index.ts
+++ b/index.ts
@@ -52,7 +52,6 @@ import {
 	scanSession,
 	isHousekeeping,
 	searchMemory,
-	getHomeDir
 } from "./lib.ts";
 
 const config = buildConfig();

--- a/index.ts
+++ b/index.ts
@@ -66,7 +66,9 @@ function gitCommit(message: string) {
 
 // --- Session scanner for "Last 24h" dashboard ---
 
-const SESSIONS_DIR = path.join(process.env.HOME ?? "~", ".pi", "agent", "sessions");
+const isWin32 = path.win32.sep === path.sep;
+const HOME = isWin32 ? process.env.HOMEPATH : process.env.HOME ?? "~";
+const SESSIONS_DIR = path.join(HOME ?? "~", ".pi", "agent", "sessions");
 const SUMMARY_CACHE = path.join(config.dailyDir, "cache.json");
 const REBUILD_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000;

--- a/lib.ts
+++ b/lib.ts
@@ -145,9 +145,24 @@ export function dailyPath(dailyDir: string, date: string): string {
 
 /** Validate and normalize a relative file path within the memory directory. Returns null if path escapes memoryDir. */
 export function safeResolvePath(memoryDir: string, filename: string): { resolved: string; normalized: string } | null {
-	const normalized = path.normalize(filename).replace(/^\/+/, "");
-	if (normalized.startsWith("..") || path.isAbsolute(filename)) return null;
-	return { resolved: path.join(memoryDir, normalized), normalized };
+	memoryDir = path.normalize(memoryDir);
+	filename = path.normalize(filename);
+
+	// Block absolute paths
+	if (/^(\\|\/)/.test(filename) || (os.platform() === 'win32' && /^\w:(\/|\\)/.test(filename))) return null;
+	
+	// Join and resolve memoryDir and filename to get the full path to the file.
+	const resolved = path.join(memoryDir, filename);
+
+
+	// Block directory traversal: Return null when joining the normalized memoryDir and filename produces a path that
+	// does not start with memoryDir.
+	if (!resolved.startsWith(memoryDir)) return null;
+
+	// Remove memoryDir from the resolved path and return it as normalized. Trim any leading slashes.
+	const normalized = resolved.replace(memoryDir, '').replace(/^(\\|\/)/, '');
+
+	return { resolved, normalized };
 }
 
 export interface IndexEntry {
@@ -239,13 +254,13 @@ export function resolveIndexedFile(config: MemoryConfig, directory: string, quer
 	const indexContent = readFileSafe(indexPath);
 	if (!indexContent) {
 		const alternatives = listSiblingIndexedDirectories(config, directory);
-		const suffix = alternatives.length > 0 ? ` Indexed directories nearby: ${alternatives.map(d => `${d}/`).join(", ")}` : "";
+		const suffix = alternatives.length > 0 ? ` Indexed directories nearby: ${alternatives.map(d => `${d}${path.sep}`).join(", ")}` : "";
 		return { text: `No INDEX.md for ${directory}.${suffix}`, details: { directory, found: false, reason: "missing_index" } };
 	}
 
 	const entries = parseIndexFile(directory, indexContent);
 	if (entries.length === 0) {
-		return { text: `No indexed entries found in ${directory}/INDEX.md.`, details: { directory, found: false, reason: "empty_index" } };
+		return { text: `No indexed entries found in ${directory}${path.sep}INDEX.md.`, details: { directory, found: false, reason: "empty_index" } };
 	}
 
 	const scored = entries
@@ -255,7 +270,7 @@ export function resolveIndexedFile(config: MemoryConfig, directory: string, quer
 
 	if (scored.length === 0) {
 		return {
-			text: formatIndexCandidates(directory, entries, `No indexed entry matched "${query}" in ${directory}/INDEX.md. Candidates:`),
+			text: formatIndexCandidates(directory, entries, `No indexed entry matched "${query}" in ${directory}${path.sep}INDEX.md. Candidates:`),
 			details: { directory, query, found: false, reason: "no_match", candidates: entries.map(e => e.filename) },
 		};
 	}
@@ -276,11 +291,11 @@ export function resolveIndexedFile(config: MemoryConfig, directory: string, quer
 	const content = readFileSafe(filePath);
 	if (!content) {
 		return {
-			text: `INDEX.md points to missing file: ${directory}/${match.filename}`,
+			text: `INDEX.md points to missing file: ${directory}${path.sep}${match.filename}`,
 			details: { directory, query, found: false, reason: "missing_resolved_file", filename: match.filename, path: filePath },
 		};
 	}
-	return { text: content, details: { path: filePath, filename: `${directory}/${match.filename}`, resolvedFrom: query, title: match.title } };
+	return { text: content, details: { path: filePath, filename: path.join(directory, match.filename), resolvedFrom: query, title: match.title } };
 }
 
 export function readMemoryFile(config: MemoryConfig, filename: string): MemoryReadResult {

--- a/lib.ts
+++ b/lib.ts
@@ -28,6 +28,11 @@ export interface FileConfig {
 	autocommit?: boolean;
 }
 
+export function getHomeDir(env: Record<string, string | undefined> = process.env) : string {
+	const isWin32 = path.win32.sep === path.sep;
+	return isWin32 ? env.HOMEPATH : env.HOME ?? "~";
+}
+
 export function loadConfigFile(memoryDir: string): FileConfig {
 	try {
 		const raw = fs.readFileSync(path.join(memoryDir, ".pi-mem.json"), "utf-8");
@@ -51,7 +56,8 @@ function parseCommaSeparated(value: string | undefined): string[] | undefined {
 }
 
 export function buildConfig(env: Record<string, string | undefined> = process.env): MemoryConfig {
-	const memoryDir = env.PI_MEMORY_DIR ?? path.join(env.HOME ?? "~", ".pi", "agent", "memory");
+	const home = getHomeDir(env);
+	const memoryDir = env.PI_MEMORY_DIR ?? path.join(home, ".pi", "agent", "memory");
 
 	// Load config.json from memory dir (env vars override file values)
 	const fileConfig = loadConfigFile(memoryDir);

--- a/lib.ts
+++ b/lib.ts
@@ -5,6 +5,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as os from "node:os";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 
@@ -57,8 +58,7 @@ function parseCommaSeparated(value: string | undefined): string[] | undefined {
 }
 
 export function buildConfig(env: Record<string, string | undefined> = process.env): MemoryConfig {
-	const home = getHomeDir(env);
-	const memoryDir = env.PI_MEMORY_DIR ?? path.join(home, ".pi", "agent", "memory");
+	const memoryDir = env.PI_MEMORY_DIR ?? path.join(env.HOME ?? os.homedir(), ".pi", "agent", "memory");
 
 	// Load config.json from memory dir (env vars override file values)
 	const fileConfig = loadConfigFile(memoryDir);

--- a/lib.ts
+++ b/lib.ts
@@ -30,11 +30,6 @@ export interface FileConfig {
 	autocommit?: boolean;
 }
 
-export function getHomeDir(env: Record<string, string | undefined> = process.env) : string {
-	const isWin32 = path.win32.sep === path.sep;
-	return isWin32 ? env.HOMEPATH : env.HOME ?? "~";
-}
-
 export function loadConfigFile(memoryDir: string): FileConfig {
 	try {
 		const raw = fs.readFileSync(path.join(memoryDir, ".pi-mem.json"), "utf-8");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -8,11 +8,11 @@ import { makeTempDir, cleanup, writeFile } from "./helpers.ts";
 describe("buildConfig", () => {
 	it("uses defaults when no env vars set", () => {
 		const config = buildConfig({ HOME: "/home/testuser" });
-		assert.strictEqual(config.memoryDir, "/home/testuser/.pi/agent/memory");
-		assert.strictEqual(config.memoryFile, "/home/testuser/.pi/agent/memory/MEMORY.md");
-		assert.strictEqual(config.scratchpadFile, "/home/testuser/.pi/agent/memory/SCRATCHPAD.md");
-		assert.strictEqual(config.dailyDir, "/home/testuser/.pi/agent/memory/daily");
-		assert.strictEqual(config.notesDir, "/home/testuser/.pi/agent/memory/notes");
+		assert.strictEqual(config.memoryDir, path.normalize("/home/testuser/.pi/agent/memory"));
+		assert.strictEqual(config.memoryFile, path.normalize("/home/testuser/.pi/agent/memory/MEMORY.md"));
+		assert.strictEqual(config.scratchpadFile, path.normalize("/home/testuser/.pi/agent/memory/SCRATCHPAD.md"));
+		assert.strictEqual(config.dailyDir, path.normalize("/home/testuser/.pi/agent/memory/daily"));
+		assert.strictEqual(config.notesDir, path.normalize("/home/testuser/.pi/agent/memory/notes"));
 		assert.deepStrictEqual(config.contextFiles, []);
 		assert.strictEqual(config.autocommit, false);
 		assert.strictEqual(config.timezone, "UTC");
@@ -24,34 +24,19 @@ describe("buildConfig", () => {
       PI_MEMORY_DIR: path.normalize("/custom/mem"),
     });
     assert.strictEqual(config.memoryDir, path.normalize("/custom/mem"));
-    assert.strictEqual(
-      config.memoryFile,
-      path.normalize("/custom/mem/MEMORY.md"),
-    );
-    assert.strictEqual(
-      config.scratchpadFile,
-      path.normalize("/custom/mem/SCRATCHPAD.md"),
-    );
+    assert.strictEqual(config.memoryFile, path.normalize("/custom/mem/MEMORY.md"));
+    assert.strictEqual(config.scratchpadFile,path.normalize("/custom/mem/SCRATCHPAD.md"));
     assert.strictEqual(config.notesDir, path.normalize("/custom/mem/notes"));
   });
 
   it("respects PI_DAILY_DIR override independently of memory dir", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_DAILY_DIR: path.normalize("/other/daily"),
-    });
+    const config = buildConfig({HOME: path.normalize("/home/x"), PI_DAILY_DIR: path.normalize("/other/daily")});
     assert.strictEqual(config.dailyDir, path.normalize("/other/daily"));
-    assert.strictEqual(
-      config.memoryDir,
-      path.normalize("/home/x/.pi/agent/memory"),
-    );
+    assert.strictEqual(config.memoryDir, path.normalize("/home/x/.pi/agent/memory"));
   });
 
   it("parses PI_CONTEXT_FILES as comma-separated list", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_CONTEXT_FILES: "SOUL.md, AGENTS.md, HEARTBEAT.md",
-    });
+    const config = buildConfig({HOME: path.normalize("/home/x"), PI_CONTEXT_FILES: "SOUL.md, AGENTS.md, HEARTBEAT.md"});
     assert.deepStrictEqual(config.contextFiles, [
       "SOUL.md",
       "AGENTS.md",
@@ -60,58 +45,37 @@ describe("buildConfig", () => {
   });
 
   it("handles empty PI_CONTEXT_FILES", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_CONTEXT_FILES: "",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_CONTEXT_FILES: "" });
     assert.deepStrictEqual(config.contextFiles, []);
   });
 
   it("handles PI_CONTEXT_FILES with extra whitespace and trailing comma", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_CONTEXT_FILES: " A.md ,  B.md , ",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_CONTEXT_FILES: " A.md ,  B.md , " });
     assert.deepStrictEqual(config.contextFiles, ["A.md", "B.md"]);
   });
 
   it("enables autocommit with PI_AUTOCOMMIT=1", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_AUTOCOMMIT: "1",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_AUTOCOMMIT: "1" });
     assert.strictEqual(config.autocommit, true);
   });
 
   it("enables autocommit with PI_AUTOCOMMIT=true", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_AUTOCOMMIT: "true",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_AUTOCOMMIT: "true" });
     assert.strictEqual(config.autocommit, true);
   });
 
   it("does not enable autocommit with PI_AUTOCOMMIT=0", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_AUTOCOMMIT: "0",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_AUTOCOMMIT: "0" });
     assert.strictEqual(config.autocommit, false);
   });
 
   it("does not enable autocommit with PI_AUTOCOMMIT=yes", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_AUTOCOMMIT: "yes",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_AUTOCOMMIT: "yes" });
     assert.strictEqual(config.autocommit, false);
   });
 
   it("parses PI_SEARCH_DIRS as comma-separated list", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_SEARCH_DIRS: "catchup, projects",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_SEARCH_DIRS: "catchup, projects" });
     assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
   });
 
@@ -136,10 +100,7 @@ describe("buildConfig", () => {
 	});
 
   it("handles PI_SEARCH_DIRS with extra whitespace and trailing comma", () => {
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_SEARCH_DIRS: " catchup ,  projects , ",
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_SEARCH_DIRS: " catchup ,  projects , " });
     assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
   });
 
@@ -153,10 +114,7 @@ describe("buildConfig", () => {
         autocommit: true,
       }),
     );
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_MEMORY_DIR: memDir,
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_MEMORY_DIR: memDir });
     assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
     assert.deepStrictEqual(config.contextFiles, ["SOUL.md"]);
     assert.strictEqual(config.autocommit, true);
@@ -189,10 +147,7 @@ describe("buildConfig", () => {
   it("ignores malformed .pi-mem.json", () => {
     const memDir = makeTempDir();
     writeFile(path.join(memDir, ".pi-mem.json"), "not json{{");
-    const config = buildConfig({
-      HOME: path.normalize("/home/x"),
-      PI_MEMORY_DIR: memDir,
-    });
+    const config = buildConfig({ HOME: path.normalize("/home/x"), PI_MEMORY_DIR: memDir });
     assert.deepStrictEqual(config.searchDirs, []);
     assert.deepStrictEqual(config.contextFiles, []);
     cleanup(memDir);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import * as path from "node:path";
+import * as os from "node:os";
 import { buildConfig } from "../lib.ts";
 import { makeTempDir, cleanup, writeFile } from "./helpers.ts";
 
@@ -17,59 +18,102 @@ describe("buildConfig", () => {
 		assert.strictEqual(config.timezone, "UTC");
 	});
 
-	it("respects PI_MEMORY_DIR override", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_MEMORY_DIR: "/custom/mem" });
-		assert.strictEqual(config.memoryDir, "/custom/mem");
-		assert.strictEqual(config.memoryFile, "/custom/mem/MEMORY.md");
-		assert.strictEqual(config.scratchpadFile, "/custom/mem/SCRATCHPAD.md");
-		assert.strictEqual(config.notesDir, "/custom/mem/notes");
-	});
+  it("respects PI_MEMORY_DIR override", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_MEMORY_DIR: path.normalize("/custom/mem"),
+    });
+    assert.strictEqual(config.memoryDir, path.normalize("/custom/mem"));
+    assert.strictEqual(
+      config.memoryFile,
+      path.normalize("/custom/mem/MEMORY.md"),
+    );
+    assert.strictEqual(
+      config.scratchpadFile,
+      path.normalize("/custom/mem/SCRATCHPAD.md"),
+    );
+    assert.strictEqual(config.notesDir, path.normalize("/custom/mem/notes"));
+  });
 
-	it("respects PI_DAILY_DIR override independently of memory dir", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_DAILY_DIR: "/other/daily" });
-		assert.strictEqual(config.dailyDir, "/other/daily");
-		assert.strictEqual(config.memoryDir, "/home/x/.pi/agent/memory");
-	});
+  it("respects PI_DAILY_DIR override independently of memory dir", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_DAILY_DIR: path.normalize("/other/daily"),
+    });
+    assert.strictEqual(config.dailyDir, path.normalize("/other/daily"));
+    assert.strictEqual(
+      config.memoryDir,
+      path.normalize("/home/x/.pi/agent/memory"),
+    );
+  });
 
-	it("parses PI_CONTEXT_FILES as comma-separated list", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_CONTEXT_FILES: "SOUL.md, AGENTS.md, HEARTBEAT.md" });
-		assert.deepStrictEqual(config.contextFiles, ["SOUL.md", "AGENTS.md", "HEARTBEAT.md"]);
-	});
+  it("parses PI_CONTEXT_FILES as comma-separated list", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_CONTEXT_FILES: "SOUL.md, AGENTS.md, HEARTBEAT.md",
+    });
+    assert.deepStrictEqual(config.contextFiles, [
+      "SOUL.md",
+      "AGENTS.md",
+      "HEARTBEAT.md",
+    ]);
+  });
 
-	it("handles empty PI_CONTEXT_FILES", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_CONTEXT_FILES: "" });
-		assert.deepStrictEqual(config.contextFiles, []);
-	});
+  it("handles empty PI_CONTEXT_FILES", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_CONTEXT_FILES: "",
+    });
+    assert.deepStrictEqual(config.contextFiles, []);
+  });
 
-	it("handles PI_CONTEXT_FILES with extra whitespace and trailing comma", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_CONTEXT_FILES: " A.md ,  B.md , " });
-		assert.deepStrictEqual(config.contextFiles, ["A.md", "B.md"]);
-	});
+  it("handles PI_CONTEXT_FILES with extra whitespace and trailing comma", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_CONTEXT_FILES: " A.md ,  B.md , ",
+    });
+    assert.deepStrictEqual(config.contextFiles, ["A.md", "B.md"]);
+  });
 
-	it("enables autocommit with PI_AUTOCOMMIT=1", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_AUTOCOMMIT: "1" });
-		assert.strictEqual(config.autocommit, true);
-	});
+  it("enables autocommit with PI_AUTOCOMMIT=1", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_AUTOCOMMIT: "1",
+    });
+    assert.strictEqual(config.autocommit, true);
+  });
 
-	it("enables autocommit with PI_AUTOCOMMIT=true", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_AUTOCOMMIT: "true" });
-		assert.strictEqual(config.autocommit, true);
-	});
+  it("enables autocommit with PI_AUTOCOMMIT=true", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_AUTOCOMMIT: "true",
+    });
+    assert.strictEqual(config.autocommit, true);
+  });
 
-	it("does not enable autocommit with PI_AUTOCOMMIT=0", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_AUTOCOMMIT: "0" });
-		assert.strictEqual(config.autocommit, false);
-	});
+  it("does not enable autocommit with PI_AUTOCOMMIT=0", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_AUTOCOMMIT: "0",
+    });
+    assert.strictEqual(config.autocommit, false);
+  });
 
-	it("does not enable autocommit with PI_AUTOCOMMIT=yes", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_AUTOCOMMIT: "yes" });
-		assert.strictEqual(config.autocommit, false);
-	});
+  it("does not enable autocommit with PI_AUTOCOMMIT=yes", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_AUTOCOMMIT: "yes",
+    });
+    assert.strictEqual(config.autocommit, false);
+  });
 
-	it("parses PI_SEARCH_DIRS as comma-separated list", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_SEARCH_DIRS: "catchup, projects" });
-		assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
-	});
+  it("parses PI_SEARCH_DIRS as comma-separated list", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_SEARCH_DIRS: "catchup, projects",
+    });
+    assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
+  });
 
 	it("uses PI_TIMEZONE before TZ", () => {
 		const config = buildConfig({ HOME: "/home/x", TZ: "UTC", PI_TIMEZONE: "America/Los_Angeles" });
@@ -91,70 +135,95 @@ describe("buildConfig", () => {
 		assert.deepStrictEqual(config.searchDirs, []);
 	});
 
-	it("handles PI_SEARCH_DIRS with extra whitespace and trailing comma", () => {
-		const config = buildConfig({ HOME: "/home/x", PI_SEARCH_DIRS: " catchup ,  projects , " });
-		assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
-	});
+  it("handles PI_SEARCH_DIRS with extra whitespace and trailing comma", () => {
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_SEARCH_DIRS: " catchup ,  projects , ",
+    });
+    assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
+  });
 
-	it("reads .pi-mem.json from memory dir", () => {
-		const memDir = makeTempDir();
-		writeFile(path.join(memDir, ".pi-mem.json"), JSON.stringify({
-			searchDirs: ["catchup", "projects"],
-			contextFiles: ["SOUL.md"],
-			autocommit: true,
-		}));
-		const config = buildConfig({ HOME: "/home/x", PI_MEMORY_DIR: memDir });
-		assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
-		assert.deepStrictEqual(config.contextFiles, ["SOUL.md"]);
-		assert.strictEqual(config.autocommit, true);
-		cleanup(memDir);
-	});
+  it("reads .pi-mem.json from memory dir", () => {
+    const memDir = makeTempDir();
+    writeFile(
+      path.join(memDir, ".pi-mem.json"),
+      JSON.stringify({
+        searchDirs: ["catchup", "projects"],
+        contextFiles: ["SOUL.md"],
+        autocommit: true,
+      }),
+    );
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_MEMORY_DIR: memDir,
+    });
+    assert.deepStrictEqual(config.searchDirs, ["catchup", "projects"]);
+    assert.deepStrictEqual(config.contextFiles, ["SOUL.md"]);
+    assert.strictEqual(config.autocommit, true);
+    cleanup(memDir);
+  });
 
-	it("env vars override .pi-mem.json values", () => {
-		const memDir = makeTempDir();
-		writeFile(path.join(memDir, ".pi-mem.json"), JSON.stringify({
-			searchDirs: ["catchup"],
-			contextFiles: ["SOUL.md"],
-			autocommit: true,
-		}));
-		const config = buildConfig({
-			HOME: "/home/x",
-			PI_MEMORY_DIR: memDir,
-			PI_SEARCH_DIRS: "projects,other",
-			PI_CONTEXT_FILES: "AGENTS.md",
-			PI_AUTOCOMMIT: "0",
-		});
-		assert.deepStrictEqual(config.searchDirs, ["projects", "other"]);
-		assert.deepStrictEqual(config.contextFiles, ["AGENTS.md"]);
-		assert.strictEqual(config.autocommit, false);
-		cleanup(memDir);
-	});
+  it("env vars override .pi-mem.json values", () => {
+    const memDir = makeTempDir();
+    writeFile(
+      path.join(memDir, ".pi-mem.json"),
+      JSON.stringify({
+        searchDirs: ["catchup"],
+        contextFiles: ["SOUL.md"],
+        autocommit: true,
+      }),
+    );
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_MEMORY_DIR: memDir,
+      PI_SEARCH_DIRS: "projects,other",
+      PI_CONTEXT_FILES: "AGENTS.md",
+      PI_AUTOCOMMIT: "0",
+    });
+    assert.deepStrictEqual(config.searchDirs, ["projects", "other"]);
+    assert.deepStrictEqual(config.contextFiles, ["AGENTS.md"]);
+    assert.strictEqual(config.autocommit, false);
+    cleanup(memDir);
+  });
 
-	it("ignores malformed .pi-mem.json", () => {
-		const memDir = makeTempDir();
-		writeFile(path.join(memDir, ".pi-mem.json"), "not json{{");
-		const config = buildConfig({ HOME: "/home/x", PI_MEMORY_DIR: memDir });
-		assert.deepStrictEqual(config.searchDirs, []);
-		assert.deepStrictEqual(config.contextFiles, []);
-		cleanup(memDir);
-	});
+  it("ignores malformed .pi-mem.json", () => {
+    const memDir = makeTempDir();
+    writeFile(path.join(memDir, ".pi-mem.json"), "not json{{");
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_MEMORY_DIR: memDir,
+    });
+    assert.deepStrictEqual(config.searchDirs, []);
+    assert.deepStrictEqual(config.contextFiles, []);
+    cleanup(memDir);
+  });
 
-	it("ignores .pi-mem.json with wrong types", () => {
-		const memDir = makeTempDir();
-		writeFile(path.join(memDir, ".pi-mem.json"), JSON.stringify({
-			searchDirs: "not-an-array",
-			contextFiles: 42,
-			autocommit: "yes",
-		}));
-		const config = buildConfig({ HOME: "/home/x", PI_MEMORY_DIR: memDir });
-		assert.deepStrictEqual(config.searchDirs, []);
-		assert.deepStrictEqual(config.contextFiles, []);
-		assert.strictEqual(config.autocommit, false);
-		cleanup(memDir);
-	});
+  it("ignores .pi-mem.json with wrong types", () => {
+    const memDir = makeTempDir();
+    writeFile(
+      path.join(memDir, ".pi-mem.json"),
+      JSON.stringify({
+        searchDirs: "not-an-array",
+        contextFiles: 42,
+        autocommit: "yes",
+      }),
+    );
+    const config = buildConfig({
+      HOME: path.normalize("/home/x"),
+      PI_MEMORY_DIR: memDir,
+    });
+    assert.deepStrictEqual(config.searchDirs, []);
+    assert.deepStrictEqual(config.contextFiles, []);
+    assert.strictEqual(config.autocommit, false);
+    cleanup(memDir);
+  });
 
-	it("falls back to ~ when HOME is undefined", () => {
-		const config = buildConfig({});
-		assert.strictEqual(config.memoryDir, "~/.pi/agent/memory");
-	});
+  it("falls back to user's home directory when HOME is undefined", () => {
+    const config = buildConfig({});
+
+    assert.strictEqual(
+      config.memoryDir,
+      path.normalize(path.join(os.homedir(), ".pi/agent/memory")),
+    );
+  });
 });

--- a/tests/date-helpers.test.ts
+++ b/tests/date-helpers.test.ts
@@ -1,12 +1,19 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { todayStr, yesterdayStr, nowTimestamp, shortSessionId, dailyPath } from "../lib.ts";
+import {
+  todayStr,
+  yesterdayStr,
+  nowTimestamp,
+  shortSessionId,
+  dailyPath,
+} from "../lib.ts";
+import path from "node:path";
 
 describe("todayStr", () => {
-	it("returns YYYY-MM-DD format", () => {
-		const result = todayStr();
-		assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
-	});
+  it("returns YYYY-MM-DD format", () => {
+    const result = todayStr();
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
 
 	it("matches current UTC date by default", () => {
 		const expected = new Date().toISOString().slice(0, 10);
@@ -21,10 +28,10 @@ describe("todayStr", () => {
 });
 
 describe("yesterdayStr", () => {
-	it("returns YYYY-MM-DD format", () => {
-		const result = yesterdayStr();
-		assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
-	});
+  it("returns YYYY-MM-DD format", () => {
+    const result = yesterdayStr();
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
 
 	it("is exactly one day before today", () => {
 		const today = new Date(todayStr());
@@ -41,44 +48,47 @@ describe("yesterdayStr", () => {
 });
 
 describe("nowTimestamp", () => {
-	it("returns space-separated date and time", () => {
-		const ts = nowTimestamp();
-		assert.match(ts, /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
-	});
+  it("returns space-separated date and time", () => {
+    const ts = nowTimestamp();
+    assert.match(ts, /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
 
-	it("does not contain T or Z", () => {
-		const ts = nowTimestamp();
-		assert.ok(!ts.includes("T"));
-		assert.ok(!ts.includes("Z"));
-	});
+  it("does not contain T or Z", () => {
+    const ts = nowTimestamp();
+    assert.ok(!ts.includes("T"));
+    assert.ok(!ts.includes("Z"));
+  });
 });
 
 describe("shortSessionId", () => {
-	it("returns first 8 characters", () => {
-		assert.strictEqual(shortSessionId("abcdefghijklmnop"), "abcdefgh");
-	});
+  it("returns first 8 characters", () => {
+    assert.strictEqual(shortSessionId("abcdefghijklmnop"), "abcdefgh");
+  });
 
-	it("handles UUID-style IDs", () => {
-		assert.strictEqual(shortSessionId("550e8400-e29b-41d4-a716-446655440000"), "550e8400");
-	});
+  it("handles UUID-style IDs", () => {
+    assert.strictEqual(
+      shortSessionId("550e8400-e29b-41d4-a716-446655440000"),
+      "550e8400",
+    );
+  });
 
-	it("handles short input gracefully", () => {
-		assert.strictEqual(shortSessionId("abc"), "abc");
-	});
+  it("handles short input gracefully", () => {
+    assert.strictEqual(shortSessionId("abc"), "abc");
+  });
 
-	it("returns empty string for empty input", () => {
-		assert.strictEqual(shortSessionId(""), "");
-	});
+  it("returns empty string for empty input", () => {
+    assert.strictEqual(shortSessionId(""), "");
+  });
 });
 
 describe("dailyPath", () => {
-	it("builds correct path for a date", () => {
-		const result = dailyPath("/mem/daily", "2026-02-18");
-		assert.strictEqual(result, "/mem/daily/2026-02-18.md");
-	});
+  it("builds correct path for a date", () => {
+    const result = dailyPath(path.normalize("/mem/daily"), "2026-02-18");
+    assert.strictEqual(result, path.normalize("/mem/daily/2026-02-18.md"));
+  });
 
-	it("handles trailing slash in dir", () => {
-		const result = dailyPath("/mem/daily/", "2026-01-01");
-		assert.ok(result.endsWith("2026-01-01.md"));
-	});
+  it("handles trailing slash in dir", () => {
+    const result = dailyPath(path.normalize("/mem/daily"), "2026-01-01");
+    assert.ok(result.endsWith("2026-01-01.md"));
+  });
 });

--- a/tests/file-helpers.test.ts
+++ b/tests/file-helpers.test.ts
@@ -75,7 +75,7 @@ describe("safeResolvePath", () => {
 	it("allows subdirectory paths", () => {
 		const result = safeResolvePath("/mem", "catchup/2026-04-26/file.md");
 		assert.ok(result);
-		assert.strictEqual(result.normalized, "catchup/2026-04-26/file.md");
+		assert.strictEqual(result.normalized, path.normalize("catchup/2026-04-26/file.md"));
 		assert.strictEqual(result.resolved, path.join("/mem", "catchup/2026-04-26/file.md"));
 	});
 
@@ -93,11 +93,18 @@ describe("safeResolvePath", () => {
 
 	it("blocks absolute paths", () => {
 		assert.strictEqual(safeResolvePath("/mem", "/etc/passwd"), null);
+		assert.strictEqual(safeResolvePath("/mem", "\\etc\\passwd"), null);
+	});
+
+	it("blocks absolute win32 paths", () => {
+		assert.strictEqual(safeResolvePath("/mem", "C:\\etc\\passwd"), null);
+		assert.strictEqual(safeResolvePath("C:\\mem", "C:/etc/passwd"), null);
+		assert.strictEqual(safeResolvePath("C:/mem", "Z:/etc/passwd"), null);
 	});
 
 	it("allows paths that resolve within memoryDir after normalization", () => {
 		const result = safeResolvePath("/mem", "catchup/2026/../2026/file.md");
 		assert.ok(result);
-		assert.strictEqual(result.normalized, "catchup/2026/file.md");
+		assert.strictEqual(result.normalized, path.normalize("catchup/2026/file.md"));
 	});
 });

--- a/tests/memory-read.test.ts
+++ b/tests/memory-read.test.ts
@@ -29,56 +29,56 @@ describe("memory_read indexed directory resolution", () => {
 
 	it("reads exact indexed files unchanged", () => {
 		const config = seedIndexedDirectory();
-		const result = readMemoryFile(config, "activity/2026-05-23/INDEX.md");
+		const result = readMemoryFile(config, path.normalize("activity/2026-05-23/INDEX.md"));
 		assert.match(result.text, /Founder Group/);
 		assert.match(result.text, /1722_chat_parent-chat\.md/);
-		assert.equal(result.details.filename, "activity/2026-05-23/INDEX.md");
+		assert.equal(result.details.filename, path.normalize("activity/2026-05-23/INDEX.md"));
 	});
 
 	it("resolves a title query through sibling INDEX.md", () => {
 		const config = seedIndexedDirectory();
-		const result = resolveIndexedFile(config, "activity/2026-05-23", "Parent Chat");
+		const result = resolveIndexedFile(config, path.normalize("activity/2026-05-23"), "Parent Chat");
 		assert.match(result.text, /Morgan discussed the door incident/);
-		assert.equal(result.details.filename, "activity/2026-05-23/1722_chat_parent-chat.md");
+		assert.equal(result.details.filename, path.normalize("activity/2026-05-23/1722_chat_parent-chat.md"));
 	});
 
 	it("resolves prefixed index titles without requiring the prefix", () => {
 		const config = seedIndexedDirectory();
-		const result = resolveIndexedFile(config, "activity/2026-05-23", "Founder Group");
+		const result = resolveIndexedFile(config, path.normalize("activity/2026-05-23"), "Founder Group");
 		assert.match(result.text, /Alex discussed LLM spend/);
-		assert.equal(result.details.filename, "activity/2026-05-23/1613_chat_founder-group.md");
+		assert.equal(result.details.filename, path.normalize("activity/2026-05-23/1613_chat_founder-group.md"));
 	});
 
 	it("self-heals hallucinated indexed file paths by consulting sibling INDEX.md", () => {
 		const config = seedIndexedDirectory();
-		const result = readMemoryFile(config, "activity/2026-05-23/Parent Chat.md");
+		const result = readMemoryFile(config, path.normalize("activity/2026-05-23/Parent Chat.md"));
 		assert.match(result.text, /Morgan discussed the door incident/);
-		assert.equal(result.details.filename, "activity/2026-05-23/1722_chat_parent-chat.md");
+		assert.equal(result.details.filename, path.normalize("activity/2026-05-23/1722_chat_parent-chat.md"));
 		assert.equal(result.details.resolvedFrom, "Parent Chat");
 	});
 
 	it("returns exact candidates for ambiguous indexed queries", () => {
 		const config = seedIndexedDirectory();
-		const result = resolveIndexedFile(config, "activity/2026-05-23", "Product");
+		const result = resolveIndexedFile(config, path.normalize("activity/2026-05-23"), "Product");
 		assert.match(result.text, /Multiple indexed entries matched "Product"/);
-		assert.match(result.text, /activity\/2026-05-23\/2336_chat_product-dev-stream\.md/);
-		assert.match(result.text, /activity\/2026-05-23\/1033_chat_product-community\.md/);
+		assert.match(result.text, /activity(\/|\\)2026-05-23(\/|\\)2336_chat_product-dev-stream\.md/);
+		assert.match(result.text, /activity(\/|\\)2026-05-23(\/|\\)1033_chat_product-community\.md/);
 		assert.equal(result.details.reason, "ambiguous");
 	});
 
 	it("gives useful nearby-directory guidance when INDEX.md is missing", () => {
 		const config = seedIndexedDirectory();
 		writeFile(path.join(config.memoryDir, "activity", "2026-05-22", "INDEX.md"), "Older index");
-		const result = resolveIndexedFile(config, "activity/2026-05-21", "Parent Chat");
-		assert.match(result.text, /No INDEX\.md for activity\/2026-05-21/);
-		assert.match(result.text, /Indexed directories nearby: activity\/2026-05-23\//);
-		assert.match(result.text, /activity\/2026-05-22\//);
+		const result = resolveIndexedFile(config, path.normalize("activity/2026-05-21"), "Parent Chat");
+		assert.match(result.text, /No INDEX\.md for activity(\/|\\)2026-05-21/);
+		assert.match(result.text, /Indexed directories nearby: activity(\/|\\)2026-05-23(\/|\\)/);
+		assert.match(result.text, /activity(\/|\\)2026-05-22(\/|\\)/);
 	});
 
 	it("gives the same guidance for hallucinated paths when INDEX.md is missing", () => {
 		const config = seedIndexedDirectory();
-		const result = readMemoryFile(config, "activity/2026-05-21/Parent Chat.md");
-		assert.match(result.text, /No INDEX\.md for activity\/2026-05-21/);
-		assert.match(result.text, /Indexed directories nearby: activity\/2026-05-23\//);
+		const result = readMemoryFile(config, path.normalize("activity/2026-05-21/Parent Chat.md"));
+		assert.match(result.text, /No INDEX\.md for activity(\/||\\)2026-05-21/);
+		assert.match(result.text, /Indexed directories nearby: activity(\/||\\)2026-05-23(\/||\\)/);
 	});
 });


### PR DESCRIPTION
- Change safeResolvePath to normalize filename and memoryDir early
- Update regex assertions to match unix or win32 path separator patterns
- Added block absolute win32 paths
- Extended bloack absolute paths to handle forward slashes case
- Pass paths through path.normalize in assertions and parameters